### PR TITLE
Nullable default param parsing fixed

### DIFF
--- a/alcubierre-codegen-test/src/main/kotlin/com/github/octaone/alcubierre/codegen/test/Screen.kt
+++ b/alcubierre-codegen-test/src/main/kotlin/com/github/octaone/alcubierre/codegen/test/Screen.kt
@@ -49,9 +49,28 @@ data class ReflectionScreen(
     val bar: String?
 ) : TestScreen()
 
-@Deeplink("scheme://host/path/{name}")
+@Deeplink("scheme://host/path/{a}/{b}/{c}/{d}/{e}/{f}/{g}/{h}")
 data class NullableScreen(
-    val name: String?
+    val a: String?,
+    val b: Int?,
+    val c: Byte?,
+    val d: Long?,
+    val e: Short?,
+    val f: Float?,
+    val g: Double?,
+    val h: Boolean?
+) : TestScreen()
+
+@Deeplink("scheme://host/path/{a}/{b}/{c}/{d}/{e}/{f}/{g}/{h}")
+data class NullableWithDefaultScreen(
+    val a: String? = "default",
+    val b: Int? = 1,
+    val c: Byte? = 2,
+    val d: Long? = 3,
+    val e: Short? = 4,
+    val f: Float? = 5f,
+    val g: Double? = 6.0,
+    val h: Boolean? = false
 ) : TestScreen()
 
 @Deeplink(

--- a/alcubierre-codegen-test/src/test/kotlin/com/github/octaone/alcubierre/codegen/test/ScreenConverterTest.kt
+++ b/alcubierre-codegen-test/src/test/kotlin/com/github/octaone/alcubierre/codegen/test/ScreenConverterTest.kt
@@ -79,8 +79,25 @@ class ScreenConverterTest {
     @Test
     fun `screen with nullable parameters`() {
         assertEquals(
-            NullableScreen(null),
+            NullableScreen(null, null, null, null, null, null, null, null),
             NullableScreen_Converter().convert(emptyMap())
+        )
+    }
+
+    @Test
+    fun `screen with nullable default parameters`() {
+        assertEquals(
+            NullableWithDefaultScreen(
+                a = "default",
+                b = 1,
+                c = 2,
+                d = 3,
+                e = 4,
+                f = 5f,
+                g = 6.0,
+                h = false
+            ),
+            NullableWithDefaultScreen_Converter().convert(mapOf())
         )
     }
 

--- a/alcubierre-codegen/src/main/kotlin/com/github/octaone/alcubierre/codegen/type/converter/ReflectionConverter.kt
+++ b/alcubierre-codegen/src/main/kotlin/com/github/octaone/alcubierre/codegen/type/converter/ReflectionConverter.kt
@@ -90,7 +90,8 @@ private fun generateReflector(
     add("val constructor = %T::class.java.getDeclaredConstructor(\n", targetClass)
     indent()
 
-    for (c in constructorParameters.map { it.className }) addStatement("%T::class.java,", c)
+    for (c in constructorParameters.map { it.className }) addStatement("%T::class.javaObjectType,", c)
+
 
     addStatement("Int::class.java,") // битовая маска
     add(DEFAULT_CONSTRUCTOR_MARKER_TYPE_BLOCK)


### PR DESCRIPTION
getDeclaredConstructors throwed exception cause of Int::class.java (and Long, Byte etc) translated to java int primitive, but java.lang.Integer.required. 